### PR TITLE
Improve the behaviour of the "This character is" shroud

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,9 +59,7 @@
                     <div class="background-image info_list_scroll_option" onclick="javascript:load_playerinfo_shroud(10)" style="background-image: url(assets/cards/card-green.png);"><span>General Info</span></div>
                     <div class="background-image info_list_scroll_option" onclick="javascript:load_playerinfo_shroud(0)" style="background-image: url(assets/cards/card-brown.png);"><span>Use Your Ability?</span></div>
                     <div class="background-image info_list_scroll_option" onclick="javascript:load_playerinfo_shroud(1)" style="background-image: url(assets/cards/card-brown.png);"><span>Choose a Player</span></div>
-                    <div class="background-image info_list_scroll_option" onclick="javascript:load_playerinfo_shroud(11)" style="background-image: url(assets/cards/card-brown.png);"><span>Choose Character 1</span></div>
-                    <div class="background-image info_list_scroll_option" onclick="javascript:load_playerinfo_shroud(12)" style="background-image: url(assets/cards/card-brown.png);"><span>Choose Character 2</span></div>
-                    <div class="background-image info_list_scroll_option" onclick="javascript:load_playerinfo_shroud(13)" style="background-image: url(assets/cards/card-brown.png);"><span>Choose Character 3</span></div>
+                    <div class="background-image info_list_scroll_option" onclick="javascript:load_playerinfo_shroud(11)" style="background-image: url(assets/cards/card-brown.png);"><span>Choose Character(s)</span></div>
                     <div class="background-image info_list_scroll_option" onclick="javascript:load_playerinfo_shroud(2)" style="background-image: url(assets/cards/card-blue.png);"><span>Not In Play</span></div>
                     <div class="background-image info_list_scroll_option" onclick="javascript:load_playerinfo_shroud(3)" style="background-image: url(assets/cards/card-red.png);"><span>This Is Your Demon</span></div>
                     <div class="background-image info_list_scroll_option" onclick="javascript:load_playerinfo_shroud(4)" style="background-image: url(assets/cards/card-red.png);"><span>These Are Your Minions</span></div>
@@ -185,6 +183,7 @@
             <div id="playerinfo_body" style="height: fit-content; width: 100%; position: absolute; text-align: center;">
                 <span id="playerinfo_title" style="color: white; font-size: 50pt;"></span><br><br>
                 <div id="playerinfo_character_landing"></div>
+                <div id="playerinfo_extra_button" onclick="javascript:add_playerinfo_character_box()"></div>
             </div>
             
         </div>

--- a/index.html
+++ b/index.html
@@ -179,13 +179,12 @@
         </div>
         
         <div id="playerinfo_shoud" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; background-image: url(assets/background-img2.webp); display: none;">
-            <div id="playerinfo_close" class="background_image" onclick="javascript:close_playerinfo_shroud()"></div>
             <div id="playerinfo_body" style="height: fit-content; width: 100%; position: absolute; text-align: center;">
                 <span id="playerinfo_title" style="color: white; font-size: 50pt;"></span><br><br>
                 <div id="playerinfo_character_landing"></div>
                 <div id="playerinfo_extra_button" onclick="javascript:add_playerinfo_character_box()"></div>
             </div>
-            
+            <div id="playerinfo_close" class="background_image" onclick="javascript:close_playerinfo_shroud()"></div>
         </div>
         
         <div id="background_select_menu" style="display: inherit; display: none;" onclick="javascript:change_background_menu_hide()">

--- a/main.css
+++ b/main.css
@@ -452,7 +452,18 @@ svg {pointer-events: none; user-select: none;}
 .background_select_scroll_body {display: inline-flex; width: 70%; height: calc(100% - 100px); pointer-events: all; padding: 50px; overflow-y: scroll; scrollbar-width: none; display: inline-flex; flex-flow: wrap; justify-content: center;}
 .background_select_scroll_body::-webkit-scrollbar {display: none;}
 
-#playerinfo_close {position: absolute; top: 5px; right: 5px; width: 85px; height: 85px; opacity: 0.4; transition: opacity linear 0.1s; cursor: pointer; background-image: url("assets/close.png");}
+#playerinfo_close {
+    position: absolute; 
+    top: 5px; 
+    right: 5px; 
+    z-index: 1;
+    width: 85px; 
+    height: 85px; 
+    opacity: 0.4; 
+    transition: opacity linear 0.1s; 
+    cursor: pointer; 
+    background-image: url("assets/close.png");
+}
 #playerinfo_close:hover {opacity: 0.6;}
 #playerinfo_character_landing {text-align: center; width: 100%; pointer-events: all;}
 .playerinfo_character {

--- a/main.css
+++ b/main.css
@@ -469,6 +469,21 @@ svg {pointer-events: none; user-select: none;}
     background-size: auto 80%; 
     background-repeat: no-repeat;
 }
+#playerinfo_extra_button {
+    position: relative;
+    margin: 10px; 
+    width: 50px; 
+    height: 50px; 
+    background-color: #44444494; 
+    border-radius: 25px; 
+    display: inline-block; 
+    cursor: pointer; 
+    pointer-events: all;
+    background-image: url(assets/person_add.png); 
+    background-position: center; 
+    background-size: auto 80%; 
+    background-repeat: no-repeat;
+}
 #playerinfo_input {height: 70px; width: 65%; font-size: 40pt; text-align: center;}
 #playerinfo_body {pointer-events: none;}
 

--- a/main.css
+++ b/main.css
@@ -456,7 +456,6 @@ svg {pointer-events: none; user-select: none;}
     position: absolute; 
     top: 5px; 
     right: 5px; 
-    z-index: 1;
     width: 85px; 
     height: 85px; 
     opacity: 0.4; 

--- a/main.js
+++ b/main.js
@@ -1404,6 +1404,15 @@ function add_playerinfo_character_box() {
   div.setAttribute("onclick", "javascript:trigger_playerinfo_character_select(" + id + ")")
   document.getElementById("playerinfo_character_landing").appendChild(div);
   document.getElementById("playerinfo_body").style.top = "calc(50% - " + document.getElementById("playerinfo_body").clientHeight / 2 + "px)";
+
+  // We want the last item to be a copy of the prior. 
+  // If the dreamer needs an extra slot for the "this player is" entry, then
+  // the first one will be the actual character! We want some measure of
+  // randomness for this.
+  if (id == 0) return;
+  const character = document.getElementById("playerinfo_character_" + (id-1)).firstChild;
+  if (character == null) return;
+  div.appendChild(character.cloneNode(true));
 }
 
 function trigger_playerinfo_character_select(id)

--- a/main.js
+++ b/main.js
@@ -1308,7 +1308,11 @@ function update_info_death_cycle(id, uid)
   }
 }
 
-
+/** 
+ * Shroud-specific data for what card to show for given IDs. 
+ * The title is what's shown at the top of the shroud. 
+ * The players is the number of characters shown, by default, on the shroud.
+ */
 const CARDS = {
   0: { "title": "Use Your Ability?", "players": 0 },
   1: { "title": "Choose a Player", "players": 0 },
@@ -1324,6 +1328,10 @@ const CARDS = {
   11: { "title": "Make your Choice", "players": 1 },
 }
 
+/**
+ * Show a particular shroud (information display screen), to show to a player.
+ * @param {Number} typeId The ID of the shroud to show the player.
+ */
 function load_playerinfo_shroud(typeId)
 {
   function mapped_specials(typeId)
@@ -1378,6 +1386,9 @@ function load_playerinfo_shroud(typeId)
   mapped_specials(typeId);
 }
 
+/**
+ * Add a character box to the playerinfo shroud currently being displayed.
+ */
 function add_playerinfo_character_box() {
   const id = document.getElementById("playerinfo_character_landing").childElementCount;
   var div = document.createElement("div");

--- a/main.js
+++ b/main.js
@@ -1376,7 +1376,6 @@ function load_playerinfo_shroud(typeId)
     add_playerinfo_character_box()
   }
   mapped_specials(typeId);
-  document.getElementById("playerinfo_body").style.top = "calc(50% - " + document.getElementById("playerinfo_body").clientHeight / 2 + "px)";
 }
 
 function add_playerinfo_character_box() {
@@ -1386,6 +1385,8 @@ function add_playerinfo_character_box() {
   div.classList = "playerinfo_character";
   div.setAttribute("onclick", "javascript:trigger_playerinfo_character_select(" + id + ")")
   document.getElementById("playerinfo_character_landing").appendChild(div);
+  console.log("calc(50% - " + document.getElementById("playerinfo_body").clientHeight / 2 + "px)");
+  document.getElementById("playerinfo_body").style.top = "calc(50% - " + document.getElementById("playerinfo_body").clientHeight / 2 + "px)";
 }
 
 function trigger_playerinfo_character_select(id)

--- a/main.js
+++ b/main.js
@@ -1336,6 +1336,11 @@ function load_playerinfo_shroud(typeId)
 {
   function mapped_specials(typeId)
   {
+    if (typeId == 8 || typeId == 9) {
+      document.getElementById("playerinfo_extra_button").style.display = "none";
+    } else {
+      document.getElementById("playerinfo_extra_button").style.display = "inline-block";
+    }
     switch (typeId)
     {
       case 2:
@@ -1384,6 +1389,8 @@ function load_playerinfo_shroud(typeId)
     add_playerinfo_character_box()
   }
   mapped_specials(typeId);
+  // For displays without any character boxes
+  document.getElementById("playerinfo_body").style.top = "calc(50% - " + document.getElementById("playerinfo_body").clientHeight / 2 + "px)";
 }
 
 /**
@@ -1396,7 +1403,6 @@ function add_playerinfo_character_box() {
   div.classList = "playerinfo_character";
   div.setAttribute("onclick", "javascript:trigger_playerinfo_character_select(" + id + ")")
   document.getElementById("playerinfo_character_landing").appendChild(div);
-  console.log("calc(50% - " + document.getElementById("playerinfo_body").clientHeight / 2 + "px)");
   document.getElementById("playerinfo_body").style.top = "calc(50% - " + document.getElementById("playerinfo_body").clientHeight / 2 + "px)";
 }
 

--- a/main.js
+++ b/main.js
@@ -1409,8 +1409,9 @@ function add_playerinfo_character_box() {
   // If the dreamer needs an extra slot for the "this player is" entry, then
   // the first one will be the actual character! We want some measure of
   // randomness for this.
-  if (id == 0) return;
-  const character = document.getElementById("playerinfo_character_" + (id-1)).firstChild;
+  const prevNode = document.getElementById("playerinfo_character_" + (id-1));
+  if (prevNode == null) return;
+  const character = prevNode.firstChild;
   if (character == null) return;
   div.appendChild(character.cloneNode(true));
 }

--- a/main.js
+++ b/main.js
@@ -1334,6 +1334,7 @@ function load_playerinfo_shroud(typeId)
         }
         break;
       case 5:
+      case 6:
         select_playerinfo_character(0, document.getElementById("info_list").getAttribute("current_player"));
         break;
       case 10:
@@ -1356,7 +1357,7 @@ function load_playerinfo_shroud(typeId)
     3: { "title": "This Is Your Demon", "players": 0 },
     4: { "title": "These Are Your Minions", "players": 0 },
     5: { "title": "You Are", "players": 1 },
-    6: { "title": "This Player Is", "players": 1 },
+    6: { "title": "This Player Is", "players": 2 },
     7: { "title": "Character Selected You", "players": 1 },
     8: { "title": "Did You Vote Today?", "players": 0 },
     9: { "title": "Did You Nominate Today?", "players": 0 },

--- a/main.js
+++ b/main.js
@@ -1308,6 +1308,22 @@ function update_info_death_cycle(id, uid)
   }
 }
 
+
+const CARDS = {
+  0: { "title": "Use Your Ability?", "players": 0 },
+  1: { "title": "Choose a Player", "players": 0 },
+  2: { "title": "These Characters are Not In Play", "players": 3 },
+  3: { "title": "This Is Your Demon", "players": 0 },
+  4: { "title": "These Are Your Minions", "players": 0 },
+  5: { "title": "You Are", "players": 1 },
+  6: { "title": "This Player Is", "players": 1 },
+  7: { "title": "Character Selected You", "players": 1 },
+  8: { "title": "Did You Vote Today?", "players": 0 },
+  9: { "title": "Did You Nominate Today?", "players": 0 },
+  10: { "title": "Info", "players": 0 },
+  11: { "title": "Make your Choice", "players": 1 },
+}
+
 function load_playerinfo_shroud(typeId)
 {
   function mapped_specials(typeId)
@@ -1335,6 +1351,7 @@ function load_playerinfo_shroud(typeId)
         break;
       case 5:
       case 6:
+      case 7:
         select_playerinfo_character(0, document.getElementById("info_list").getAttribute("current_player"));
         break;
       case 10:
@@ -1350,35 +1367,25 @@ function load_playerinfo_shroud(typeId)
         break;
     }
   }
-  let cards = {
-    0: { "title": "Use Your Ability?", "players": 0 },
-    1: { "title": "Choose a Player", "players": 0 },
-    2: { "title": "These Characters are Not In Play", "players": 3 },
-    3: { "title": "This Is Your Demon", "players": 0 },
-    4: { "title": "These Are Your Minions", "players": 0 },
-    5: { "title": "You Are", "players": 1 },
-    6: { "title": "This Player Is", "players": 2 },
-    7: { "title": "Character Selected You", "players": 1 },
-    8: { "title": "Did You Vote Today?", "players": 0 },
-    9: { "title": "Did You Nominate Today?", "players": 0 },
-    10: { "title": "Info", "players": 3 },
-    11: { "title": "Make your Choice", "players": 1 },
-    12: { "title": "Make your Choices", "players": 2 },
-    13: { "title": "Make your Choices", "players": 3 }
-  }
+  const card = CARDS[typeId];
   document.getElementById("playerinfo_shoud").style.display = "inherit";
-  document.getElementById("playerinfo_title").innerHTML = cards[typeId]["title"];
+  document.getElementById("playerinfo_title").innerHTML = card["title"];
   document.getElementById("playerinfo_character_landing").innerHTML = "";
-  for (i = 0; i < cards[typeId]["players"]; i++)
+  for (i = 0; i < card["players"]; i++)
   {
-    var div = document.createElement("div");
-    div.id = "playerinfo_character_" + i;
-    div.classList = "playerinfo_character";
-    div.setAttribute("onclick", "javascript:trigger_playerinfo_character_select(" + i + ")")
-    document.getElementById("playerinfo_character_landing").appendChild(div);
+    add_playerinfo_character_box()
   }
   mapped_specials(typeId);
   document.getElementById("playerinfo_body").style.top = "calc(50% - " + document.getElementById("playerinfo_body").clientHeight / 2 + "px)";
+}
+
+function add_playerinfo_character_box() {
+  const id = document.getElementById("playerinfo_character_landing").childElementCount;
+  var div = document.createElement("div");
+  div.id = "playerinfo_character_" + id;
+  div.classList = "playerinfo_character";
+  div.setAttribute("onclick", "javascript:trigger_playerinfo_character_select(" + id + ")")
+  document.getElementById("playerinfo_character_landing").appendChild(div);
 }
 
 function trigger_playerinfo_character_select(id)


### PR DESCRIPTION
I polled the BOTC club for minor improvements to the grimoire. This was their most immediate suggestion. 

- Changed the "this player is" and "this character selected you" shrouds to fill in the character whose menu was open at the time you enabled the shroud. 
- Added the ability to add additional ad-hoc amounts of character selectors to a shroud. This allows more than 3 characters to be shown on the info screen, or multiple characters to be shown on the "This player is" screen. 
- Changed the info tab no longer have any character selectors by default. If necessary, selectors can be added using the newly added method. 

This is beneficial for characters such as the dreamer, grandmother, or cerenovus, as some of the information can be automatically filled in for the Storyteller.
![image](https://github.com/user-attachments/assets/e879a742-58a0-4343-b043-c1abee92eed4)
