### PR TITLE
Add flavor (to taste)

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
                     <div id="info_title_field"></div>
                     <div id="info_name_field"></div>
                     <div id="info_desc_field"></div>
+                    <div id="info_flavor_field"></div>
                 </div>
             </div>
             <div id="info_list" class="info_tab">

--- a/main.css
+++ b/main.css
@@ -177,6 +177,18 @@ svg {pointer-events: none; user-select: none;}
 #info_title_field {height: 100px; position: absolute; top: 0px; left: 0px; color:rgb(211, 211, 211); font-size: 50pt; font-family: PiratesBay;}
 #info_name_field {position: absolute; top: 70px; left: 30px; color:rgb(192, 72, 72); font-size: 17pt; font-family: PiratesBay;}
 #info_desc_field {position: absolute; width: calc(100vw - 600px); top: 95px; left: 15px; color:darkgrey; font-size: 24pt; font-family: PiratesBay; overflow-wrap: break-word; white-space: normal; text-align: left;}
+#info_flavor_field {
+    position: absolute;
+    width: calc(100vw - 600px);
+    top: 180px;
+    left: 15px;
+    font-size: 12pt;
+    font-style: italic;
+    font-family: PiratesBay;
+    overflow-wrap: break-word;
+    white-space: normal;
+    text-align: left;
+}
 
 #info_list {width: 100px; transition: width ease-in-out 0.2s;}
 #info_list:is([focus="true"]) {width: calc(100% - 465px);}

--- a/scripts/infoBox.js
+++ b/scripts/infoBox.js
@@ -24,6 +24,13 @@ async function infoCall(id, uid) {
     document.getElementById("info_box").style.display = "inherit";
     document.getElementById("info_token_dragbox").innerHTML = "";
 
+    if (role["flavor"] !== undefined) {
+        document.getElementById("info_flavor_field").innerHTML = `"${(role["flavor"] ?? "").replaceAll(/\n[\t ]*/g, " / ")}"`;
+        document.getElementById("info_flavor_field").style.color = ["minion", "demon"].includes(role.team) ? "rgb(230, 176, 176)" : "rgb(176, 176, 230)"
+    } else {
+        document.getElementById("info_flavor_field").innerHTML = "";
+    }
+
     update_info_death_cycle(id, uid);
 
     if (role.reminders == undefined) return;


### PR DESCRIPTION
A stupid little change from the old big PR I made a while ago. 

All of the TPI characters have flavor text. This is already a part of the tokens.json document, and is automatically scraped from TPI when we get new characters. 

This just displays it. The color is based on what team the character is. Otherwise vertically long texts (eg: [Pixie's poem](https://wiki.bloodontheclocktower.com/Pixie)) are seperated by slashes. Formatting of weird text is handled by HTML. 
![image](https://github.com/user-attachments/assets/74cf2769-1e9d-4d31-a33b-fb4f4cbe4d99)
![image](https://github.com/user-attachments/assets/e8094389-27cc-40c2-b989-cff0adab550d)

Characters with no flavor text (Unreleased experimental, Homebrew) just hide this field.
![image](https://github.com/user-attachments/assets/bed21c30-387c-401e-b540-fa3eb4e3aaec)

