### PR TITLE
Delete Fabled Reminders when cleaning the grim

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,26 +20,21 @@ var loading = false;
  * Load all non-JS files into the application to finish initialization.
  * This function is called as soon as the HTML is loaded.
  */
-async function loaded()
-{
-  loading = true;
+async function loaded() {
+    loading = true;
 
-  base_roles = await get_JSON("tokens.json");
-  roles = JSON.parse(JSON.stringify(base_roles));
+    base_roles = await get_JSON("tokens.json");
+    roles = JSON.parse(JSON.stringify(base_roles));
 
-  dragPipLayerSpawnDefault("good");
-  dragPipLayerSpawnDefault("evil");
-  dragPipLayerSpawnDefault("reminder_pip");
-  
-  load_scripts().then(() =>
-  {
-    load_game_state_json(localStorage.getItem("state"))
-  })
-  setTimeout(function ()
-  {
-    loading = false;
-    player_count_change();
-  }, 2000)
-  document.getElementById("body_actual").setAttribute("orientation", getOrientation())
-  window.onresize = resized;
+    resetDragPipLayer();
+
+    load_scripts().then(() => {
+        load_game_state_json(localStorage.getItem("state"))
+    })
+    setTimeout(function () {
+        loading = false;
+        player_count_change();
+    }, 2000)
+    document.getElementById("body_actual").setAttribute("orientation", getOrientation())
+    window.onresize = resized;
 }

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -193,7 +193,6 @@ function shuffle_roles() {
         }
     }
     shuffle(ids);
-    var offset = 0
     for (let i = 0, j = 0; i < tokens.length; i++) {
         if (tokens[i].getAttribute("visibility") == "show") {
             mutate_token(tokens[i].id.match(/.*(?=_token_)/)[0], tokens[i].getAttribute("uid"), ids[j++]);
@@ -209,12 +208,10 @@ function clean_board() {
     for (let it = tokens.length - 1; it >= 0; it--) {
         remove_token(tokens[it].id.match(/.*(?=_token_)/)[0], tokens[it].getAttribute("uid"))
     }
-    const pips = document.getElementById("dragPipLayer").children;
-    for (let it = pips.length - 1; it >= 0; it--) {
-        if (pips[it].getAttribute("stacked") == "false") {
-            delete_reminder(pips[it].id);
-        }
-    }
+    document.getElementById("reminder_layer").innerHTML = "";
+    
+    resetDragPipLayer();
+
     clear_night_order();
     save_game_state();
 }

--- a/scripts/nightOrder.js
+++ b/scripts/nightOrder.js
@@ -100,7 +100,6 @@ async function populate_night_order() {
     );
     CURRENT_SCRIPT.filter(role => role.team == "fabled").forEach(role => aliveRoles.add(role.id))
 
-    console.log(aliveRoles)
     inPlayRoles.sort((a, b) => roles[a][night] - roles[b][night]);
 
     let defaultIndex = 0
@@ -240,7 +239,6 @@ function gen_night_order_tab_role(token_JSON, night, dead) {
  * @param {String} reminder The index into the object to get the reminder string.
  */
 function gen_night_order_tab_info(info, reminder) {
-    console.log(info)
     div = document.createElement("div");
     div.classList = "night_order_tab";
     img = document.createElement("img");

--- a/scripts/reminder.js
+++ b/scripts/reminder.js
@@ -203,6 +203,13 @@ function dragPipLayerSpawnDefault(type) {
     document.getElementById("dragPipLayer").prepend(div);
 }
 
+function resetDragPipLayer() {
+    document.getElementById("dragPipLayer").innerHTML = "";
+    dragPipLayerSpawnDefault("good");
+    dragPipLayerSpawnDefault("evil");
+    dragPipLayerSpawnDefault("reminder_pip");
+}
+
 /**
  * Prompt the user if they want to delete a reminder.
  * the prompt consists simply of a trash icon appearing over the reminder.


### PR DESCRIPTION
Currently, using the clean button does not delete Fabled reminders. This is due to an oversight in how the reminder layer is cleared: we only delete reminders when we delete the assosicated tokens. Fabled aren't actually tokens (for now?), so their reminders never get deleted. 

This makes it so all reminders are universally discarded on clean. 