### PR TITLE
Add uploaded scripts to the Script list

### DIFF
--- a/scripts/gameState.js
+++ b/scripts/gameState.js
@@ -41,150 +41,147 @@ var CURRENT_SCRIPT;
  * Convert the game state to a JSON string.
  * @returns A JSON string containing the game state.
  */
-function generate_game_state_json()
-{
-  var state = new Object();
-  state.script = CURRENT_SCRIPT;
-  state.scriptColor = document.getElementById("script_upload_feedback").getAttribute("used");
-  state.scriptNumber = document.getElementById("script_options").selectedIndex;
-  state.playercount = document.getElementById("player_count").value;
-  state.night = document.getElementById("body_actual").getAttribute("night");
-  state.orientation = document.getElementById("body_actual").getAttribute("orientation");
-  state.background = document.getElementById("body_actual").style.getPropertyValue("--BG-IMG");
-  state.players = [];
-  players = document.getElementById("token_layer").getElementsByClassName("role_token");
-
-  // Each player and their tokens.
-  for (i = 0; i < players.length; i++)
-  {
-    state.players[i] = new Object();
-    state.players[i].role = players[i].getAttribute("role");
-    state.players[i].uid = players[i].getAttribute("uid");
-    state.players[i].visibility = players[i].getAttribute("visibility");
-    state.players[i].viability = players[i].getAttribute("viability");
-    state.players[i].cat = players[i].getAttribute("cat");
-    state.players[i].show_face = players[i].getAttribute("show_face");
-    state.players[i].left = players[i].style.left;
-    state.players[i].top = players[i].style.top;
-    state.players[i].name = players[i].getElementsByClassName("token_text")[0].innerHTML;
-    reminders = [];
-    reminderdivs = players[i].getElementsByClassName("reminder drag");
-    for(const attachedReminder of reminderdivs){
-      if (attachedReminder.getAttribute("role") == null) {
-        reminders.push([
-          attachedReminder.getAttribute("alignment")
-      ])
-      } else{
-        reminders.push([
-          attachedReminder.getAttribute("role"),
-          attachedReminder.getElementsByClassName("reminder_text")[0].innerHTML, 
-          attachedReminder.getAttribute("uid")
-      ])
-      }
+function generate_game_state_json() {
+    var state = new Object();
+    state.script = CURRENT_SCRIPT;
+    state.scriptColor = document.getElementById("script_upload_feedback").getAttribute("used");
+    state.scriptNumber = document.getElementById("script_options").selectedIndex;
+    if (state.scriptNumber > KNOWN_SCRIPTS.length) {
+        state.scriptNumber = KNOWN_SCRIPTS.length;
     }
-    state.players[i].reminders = reminders;
-  }
-  state.reminders = [];
-  reminders = document.getElementById("reminder_layer").getElementsByClassName("reminder");
-  for (i = 0; i < reminders.length; i++)
-  {
-    state.reminders[i] = new Object();
-    state.reminders[i].id = reminders[i].getAttribute("role");
-    state.reminders[i].text = reminders[i].children[2].innerText;
-    state.reminders[i].uid = reminders[i].getAttribute("uid");
-    state.reminders[i].left = reminders[i].style.left;
-    state.reminders[i].top = reminders[i].style.top;
-  }
 
-  // Pips are the alignment and "special" tokens on the left.
-  state.pips = Array.from(document.getElementById("dragPipLayer").getElementsByClassName("reminder"))
-    // The "generator" pips have the "stacked" attribute set.
-    .filter(pip => pip.getAttribute("stacked") === "false")
-    .map(pip => {
-      return {
-        type: pip.getAttribute("alignment"),
-        left: pip.style.left,
-        top: pip.style.top,
-      }
-    });
-  return JSON.stringify(state);
+    state.playercount = document.getElementById("player_count").value;
+    state.night = document.getElementById("body_actual").getAttribute("night");
+    state.orientation = document.getElementById("body_actual").getAttribute("orientation");
+    state.background = document.getElementById("body_actual").style.getPropertyValue("--BG-IMG");
+    state.players = [];
+    players = document.getElementById("token_layer").getElementsByClassName("role_token");
+
+    // Each player and their tokens.
+    for (i = 0; i < players.length; i++) {
+        state.players[i] = new Object();
+        state.players[i].role = players[i].getAttribute("role");
+        state.players[i].uid = players[i].getAttribute("uid");
+        state.players[i].visibility = players[i].getAttribute("visibility");
+        state.players[i].viability = players[i].getAttribute("viability");
+        state.players[i].cat = players[i].getAttribute("cat");
+        state.players[i].show_face = players[i].getAttribute("show_face");
+        state.players[i].left = players[i].style.left;
+        state.players[i].top = players[i].style.top;
+        state.players[i].name = players[i].getElementsByClassName("token_text")[0].innerHTML;
+        reminders = [];
+        reminderdivs = players[i].getElementsByClassName("reminder drag");
+        for (const attachedReminder of reminderdivs) {
+            if (attachedReminder.getAttribute("role") == null) {
+                reminders.push([
+                    attachedReminder.getAttribute("alignment")
+                ])
+            } else {
+                reminders.push([
+                    attachedReminder.getAttribute("role"),
+                    attachedReminder.getElementsByClassName("reminder_text")[0].innerHTML,
+                    attachedReminder.getAttribute("uid")
+                ])
+            }
+        }
+        state.players[i].reminders = reminders;
+    }
+    state.reminders = [];
+    reminders = document.getElementById("reminder_layer").getElementsByClassName("reminder");
+    for (i = 0; i < reminders.length; i++) {
+        state.reminders[i] = new Object();
+        state.reminders[i].id = reminders[i].getAttribute("role");
+        state.reminders[i].text = reminders[i].children[2].innerText;
+        state.reminders[i].uid = reminders[i].getAttribute("uid");
+        state.reminders[i].left = reminders[i].style.left;
+        state.reminders[i].top = reminders[i].style.top;
+    }
+
+    // Pips are the alignment and "special" tokens on the left.
+    state.pips = Array.from(document.getElementById("dragPipLayer").getElementsByClassName("reminder"))
+        // The "generator" pips have the "stacked" attribute set.
+        .filter(pip => pip.getAttribute("stacked") === "false")
+        .map(pip => {
+            return {
+                type: pip.getAttribute("alignment"),
+                left: pip.style.left,
+                top: pip.style.top,
+            }
+        });
+    return JSON.stringify(state);
 }
 
 /**
  * Load a JSON string encoding the game state onto the grimoire.
  * @param {String} state a string encoding the JSON of a game state.
  */
-async function load_game_state_json(state)
-{
-  state = JSON.parse(state);
-  if (state == null)
-  {
+async function load_game_state_json(state) {
+    state = JSON.parse(state);
+    if (state == null) {
+        loading = false;
+        return;
+    }
+    loading = true;
+    await populate_script(state.script);
+    document.getElementById("script_upload_feedback").setAttribute("used", state.scriptColor);
+    if (state.scriptNumber >= KNOWN_SCRIPTS.length) {
+        appendScriptToDropdown(state.script[0].name);
+        uploadedScripts.push(state.script);
+        document.getElementById("script_options").selectedIndex = KNOWN_SCRIPTS.length;
+    } else {
+        document.getElementById("script_options").selectedIndex = state.scriptNumber;
+    }
+    document.getElementById("player_count").value = state.playercount;
+    document.getElementById("body_actual").setAttribute("night", state.night);
+    document.getElementById("body_actual").style.setProperty("--BG-IMG", state.background);
+    for (let i = 0; i < state.players.length; i++) {
+        spawnToken(state.players[i].role, state.players[i].uid, state.players[i].visibility, state.players[i].cat, state.players[i].hide_face, state.players[i].viability, state.players[i].left, state.players[i].top, state.players[i].name, state.players[i].reminders)
+    }
+    for (const reminder of state.reminders) {
+        if (!reminder.text) {
+            const idParts = reminder.id.split("_");
+            reminder.id = idParts[0];
+            reminder.text = idParts.slice(1).map(x => x[0].toUpperCase() + x.substring(1)).join(" ");
+        }
+        spawnReminder(reminder.id, reminder.text, reminder.uid, reminder.left, reminder.top);
+    }
+    for (const pip of state.pips) {
+        const div = dragPipLayerSpawn(pip.type, pip.left, pip.top, "false")
+        document.getElementById("dragPipLayer").prepend(div);
+    }
+    if (state.orientation != getOrientation()) {
+        orientationChange();
+    }
     loading = false;
-    return;
-  }
-  loading = true;
-  await populate_script(state.script);
-  document.getElementById("script_upload_feedback").setAttribute("used", state.scriptColor);
-  document.getElementById("script_options").selectedIndex = state.scriptNumber;
-  document.getElementById("player_count").value = state.playercount;
-  document.getElementById("body_actual").setAttribute("night", state.night);
-  document.getElementById("body_actual").style.setProperty("--BG-IMG", state.background);
-  for (let i = 0; i < state.players.length; i++)
-  {
-    spawnToken(state.players[i].role, state.players[i].uid, state.players[i].visibility, state.players[i].cat, state.players[i].hide_face, state.players[i].viability, state.players[i].left, state.players[i].top, state.players[i].name, state.players[i].reminders)
-  }
-  for (const reminder of state.reminders) 
-  {
-    if (!reminder.text) {
-      const idParts = reminder.id.split("_");
-      reminder.id = idParts[0];
-      reminder.text = idParts.slice(1).map(x => x[0].toUpperCase() + x.substring(1)).join(" ");
-    } 
-    spawnReminder(reminder.id, reminder.text, reminder.uid, reminder.left, reminder.top);
-  }
-  for (const pip of state.pips)
-  {
-    const div = dragPipLayerSpawn(pip.type, pip.left, pip.top, "false")
-    document.getElementById("dragPipLayer").prepend(div);
-  }
-  if (state.orientation != getOrientation())
-  {
-    orientationChange();
-  }
-  loading = false;
 }
 
 /**
  * Take the game state of the grimoire and store it in local storage.
  */
-function save_game_state()
-{
-  localStorage.setItem("state", generate_game_state_json())
+function save_game_state() {
+    localStorage.setItem("state", generate_game_state_json())
 }
 
 /**
  * Upload a game state JSON from the computer and load it onto the grimoire.
  */
-async function game_state_upload()
-{
-  let json = await document.getElementById("game_state_upload").files[0].text();
-  load_game_state_json(json).then(() =>
-  {
-    save_game_state();
-  })
+async function game_state_upload() {
+    let json = await document.getElementById("game_state_upload").files[0].text();
+    load_game_state_json(json).then(() => {
+        save_game_state();
+    })
 }
 
 /**
  * Convert the game state into a JSON file and download it
  * to the user's computer.
  */
-function download_game_state()
-{
-  var element = document.createElement('a');
-  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(generate_game_state_json()));
-  element.setAttribute('download', "game_state.json");
-  element.style.display = 'none';
-  document.body.appendChild(element);
-  element.click();
-  document.body.removeChild(element);
+function download_game_state() {
+    var element = document.createElement('a');
+    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(generate_game_state_json()));
+    element.setAttribute('download', "game_state.json");
+    element.style.display = 'none';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
 }

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -30,6 +30,9 @@ const ASSIGNABLE_TEAMS = {
     },
 }
 
+let KNOWN_SCRIPTS = [];
+const uploadedScripts = [];
+
 /**
  * Get a JSON file from the server.
  * @param {String} path A relative path to the file on the server.
@@ -39,20 +42,27 @@ async function get_JSON(path) {
     return await (await fetch("./data/" + path)).json();
 }
 
+function appendScriptToDropdown(name) {
+    const option = document.createElement("option");
+    const optionText = document.createTextNode(name || "Untitled Script");
+    option.appendChild(optionText);
+
+    document.getElementById("script_options").appendChild(option);
+}
+
 /**
  * Load all of the scripts from the server.
  */
 async function load_scripts() {
-    var scripts = await get_JSON("scripts/scripts.json")
-    var initScript;
-    for (i = 0; i < scripts.length; i++) {
-        var element = scripts[i]
-        var script = await get_JSON("scripts/" + element["file"] + ".json");
-        if (i == 0) { initScript = script; }
-        option = document.createElement("option");
-        optionText = document.createTextNode(script[0]["name"]);
-        option.appendChild(optionText);
-        document.getElementById("script_options").appendChild(option);
+    KNOWN_SCRIPTS = await get_JSON("scripts/scripts.json")
+    let initScript;
+
+    for (const element of KNOWN_SCRIPTS) {
+        const script = await get_JSON("scripts/" + element["file"] + ".json");
+        if (initScript == undefined) initScript = script;
+
+        element.name = script[0]["name"];
+        appendScriptToDropdown(script[0]["name"]);
     }
     populate_script(initScript)
 }
@@ -61,8 +71,14 @@ async function load_scripts() {
  * Initialize the selected script from the script_options dropdown.
  */
 async function script_select() {
-    var script_names = await get_JSON("scripts/scripts.json");
-    var script = await get_JSON("scripts/" + script_names[document.getElementById("script_options").options.selectedIndex]["file"] + ".json");
+    console.log("SELECTION!")
+    const scriptIndex = parseInt(document.getElementById("script_options").options.selectedIndex);
+    let script;
+    if (scriptIndex < KNOWN_SCRIPTS.length) {
+        script = await get_JSON("scripts/" + KNOWN_SCRIPTS[document.getElementById("script_options").options.selectedIndex]["file"] + ".json");
+    } else {
+        script = uploadedScripts[scriptIndex - KNOWN_SCRIPTS.length];
+    }
     document.getElementById("script_upload_feedback").setAttribute("used", "select");
     document.getElementById("script_upload").value = "";
     populate_script(script);
@@ -84,16 +100,26 @@ async function script_upload() {
             }
         }
     }
+
+    let success = true;
     try {
         // Sanity check
         json[0]["id"]
         await populate_script(json);
         document.getElementById("script_upload_feedback").setAttribute("used", "upload");
     } catch (e) {
+        success = false;
         console.error(e);
         document.getElementById("script_upload_feedback").innerHTML = "Error Processing File";
         document.getElementById("script_upload_feedback").setAttribute("used", "error");
     }
+
+    if (success) {
+        uploadedScripts.push(json);
+        appendScriptToDropdown(json[0]["name"]);
+        document.getElementById("script_options").selectedIndex = document.getElementById("script_options").options.length - 1;
+    }
+
     document.getElementById("menu_settings_dropdown").style.height = "calc(" + document.getElementById("menu_settings_dropdown_body").scrollHeight + "px + 68px)";
     if (!loading) { save_game_state(); }
 }
@@ -104,8 +130,10 @@ async function script_upload() {
  * @param {Object} script a container with all of the characters in the script
  */
 async function populate_script(script) {
+    console.log(script)
+    console.trace();
     CURRENT_SCRIPT = script;
-    document.getElementById("script_upload_feedback").innerHTML = script[0]["name"];
+    document.getElementById("script_upload_feedback").innerHTML = script[0]["name"] || "Untitled Script";
     const rolesOnScript = [];
     script.forEach(element => {
         if (element.id.startsWith("_")) return;


### PR DESCRIPTION
The "Script" list does not currently store an entry for the currently loaded script. If someone misclicks it, some other script (usually Gang's all here) is selected immediately, meaning they are forced to reupload their script again. 

Modified the script list to add new scripts to itself when a script is uploaded. 
<img width="264" height="400" alt="image" src="https://github.com/user-attachments/assets/6610ea1e-04e0-4ee5-bd9e-f8e3b23ae6ce" />

These appear at the bottom, underneath the default scripts. When a script is uploaded, it is added to this list and selected. This applies to all scripts uploaded this session, so you can quickly swap between them if needed. If you refresh the page, the script used by the current gamestate persists, and the other scripts are forgotten. 

Also, some scripts I used in testing had blank names, so I added a failsafe that if a script has no name it gets the name "Untitled Script". 
<img width="264" height="264" alt="image" src="https://github.com/user-attachments/assets/7326dd93-d866-4630-a417-836f2b67a203" />
