### PR TITLE
Role count validation

### DIFF
--- a/adding_tokens.md
+++ b/adding_tokens.md
@@ -28,21 +28,12 @@
         "otherNightReminder": "",
         // If the character affects setup, it does so here. 
         "change_makeup": [
-            // Each entry is an object with one element.
+            // Each entry is a seperate object
             {
-                // HARD, SOFTPOS, SOFTNEG, LOCK, or REQ.
-                "HARD": [
-                    // Character type, and how many to increase/decrease/lock to. 
-                    "out",
-                    2
-                ]
-            },
-            {
-                "REQ": [
-                    // Type of character, and what character must also be added.
-                    "townsfolk",
-                    "atheist"
-                ]
+                // The type of change: FORCED_CHANGE, ALLOWED_INCREASE/ALLOWED_DECREASE, 
+                "type": "FORCED_CHANGE",
+                "team": "outsider",
+                "amount": 1
             }
         ],
         // Does nothing, leave false.

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -255,34 +255,16 @@
         "otherNightReminder": "",
         "change_makeup": [
             {
-                "LOCK": [
-                    "dem",
-                    0
-                ]
+                "type": "ZERO",
+                "team": "minion"
             },
             {
-                "LOCK": [
-                    "min",
-                    0
-                ]
+                "type": "ZERO",
+                "team": "demon"
             },
             {
-                "LOCK": [
-                    "out",
-                    -1
-                ]
-            },
-            {
-                "LOCK": [
-                    "townsfolk",
-                    -1
-                ]
-            },
-            {
-                "LOCK": [
-                    "trav",
-                    -1
-                ]
+                "type": "ARBITRARY",
+                "team": "outsider"
             }
         ],
         "image": "assets/icons/official/atheist.png",
@@ -328,16 +310,9 @@
         "otherNightReminder": "Choose a character type that does not yet have a Seen reminder next to a character of that type. Point to a player whose character is of that type, if there are any. Place the Balloonist's Seen reminder next to that character.",
         "change_makeup": [
             {
-                "SOFTPOS": [
-                    "out",
-                    1
-                ]
-            },
-            {
-                "SOFTNEG": [
-                    "townsfolk",
-                    1
-                ]
+                "type": "ALLOWED_INCREASE",
+                "team": "outsider",
+                "amount": 1
             }
         ],
         "image": "assets/icons/official/balloonist.png",
@@ -434,16 +409,9 @@
         "otherNightReminder": "",
         "change_makeup": [
             {
-                "HARD": [
-                    "out",
-                    2
-                ]
-            },
-            {
-                "HARD": [
-                    "townsfolk",
-                    -2
-                ]
+                "type": "FORCED_CHANGE",
+                "team": "outsider",
+                "amount": 2
             }
         ],
         "image": "assets/icons/official/baron.png",
@@ -520,7 +488,13 @@
         ],
         "firstNightReminder": "Show the finger signal (0, 1, 2) for the number of outsiders in play.",
         "otherNightReminder": "",
-        "change_makeup": [],
+        "change_makeup": [
+            {
+                "type": "FORCED_CHANGE",
+                "team": "outsider",
+                "amount": 1
+            }
+        ],
         "image": "assets/icons/official/blacksmith.png",
         "firstNight": 0,
         "otherNight": 0
@@ -918,10 +892,8 @@
         "otherNightReminder": "If the King was killed by the Demon, wake the Choirboy and point to the Demon player.",
         "change_makeup": [
             {
-                "REQ": [
-                    "townsfolk",
-                    "king"
-                ]
+                "type": "REQUIRED",
+                "role": "king"
             }
         ],
         "image": "assets/icons/official/choirboy.png",
@@ -1151,7 +1123,12 @@
         ],
         "firstNightReminder": "",
         "otherNightReminder": "The Dolomite chooses a player, change their alignment to Evil and inform them. Decide if the Dolomite loses their ability.",
-        "change_makeup": [],
+        "change_makeup": [
+            {
+                "type": "ZERO",
+                "team": "minion"
+            }
+        ],
         "image": "assets/icons/official/dolomite.png",
         "firstNight": 0,
         "otherNight": 0
@@ -1361,16 +1338,9 @@
         "otherNightReminder": "The Fang Gu points to a player. That player dies. Or, if that player was an Outsider and there are no other Fang Gu in play: The Fang Gu dies instead of the chosen player. The chosen player is now an evil Fang Gu. Wake the new Fang Gu. Show the 'You are' card, then the Fang Gu token. Show the 'You are' card, then the thumb-down 'evil' hand sign.",
         "change_makeup": [
             {
-                "HARD": [
-                    "out",
-                    1
-                ]
-            },
-            {
-                "HARD": [
-                    "townsfolk",
-                    -1
-                ]
+                "type": "FORCED_CHANGE",
+                "team": "outsider",
+                "amount": 1
             }
         ],
         "image": "assets/icons/official/fanggu.png",
@@ -1663,28 +1633,9 @@
         "otherNightReminder": "If an Outsider died today: The Godfather points to a player. That player dies.",
         "change_makeup": [
             {
-                "SOFTPOS": [
-                    "out",
-                    1
-                ]
-            },
-            {
-                "SOFTNEG": [
-                    "out",
-                    1
-                ]
-            },
-            {
-                "SOFTPOS": [
-                    "townsfolk",
-                    1
-                ]
-            },
-            {
-                "SOFTNEG": [
-                    "townsfolk",
-                    1
-                ]
+                "type": "OFFSET",
+                "team": "outsider",
+                "amount": 1
             }
         ],
         "image": "assets/icons/official/godfather.png",
@@ -1974,7 +1925,13 @@
         "reminders": [],
         "firstNightReminder": "",
         "otherNightReminder": "",
-        "change_makeup": [],
+        "change_makeup": [
+            {
+                "type": "ALLOWED_DECREASE",
+                "team": "outsider",
+                "amount": 1
+            }
+        ],
         "image": "assets/icons/official/hermit.png",
         "firstNight": 0,
         "otherNight": 0,
@@ -2021,10 +1978,8 @@
         "otherNightReminder": "The Huntsman shakes their head 'no' or points to a player. If they point to the Damsel, wake that player, show the 'You are' card and a not-in-play character token.",
         "change_makeup": [
             {
-                "REQ": [
-                    "townsfolk",
-                    "damsel"
-                ]
+                "type": "REQUIRED",
+                "role": "damsel"
             }
         ],
         "image": "assets/icons/official/huntsman.png",
@@ -2200,28 +2155,8 @@
         "otherNightReminder": "Wake the Kazali and allow them to pick one player, they die",
         "change_makeup": [
             {
-                "SOFTPOS": [
-                    "out",
-                    2
-                ]
-            },
-            {
-                "SOFTNEG": [
-                    "out",
-                    2
-                ]
-            },
-            {
-                "SOFTPOS": [
-                    "townsfolk",
-                    2
-                ]
-            },
-            {
-                "SOFTNEG": [
-                    "townsfolk",
-                    2
-                ]
+                "type": "ARBITRARY",
+                "team": "outsider"
             }
         ],
         "image": "assets/icons/official/kazali.png",
@@ -2355,7 +2290,20 @@
         ],
         "firstNightReminder": "",
         "otherNightReminder": "Choose a player, that player dies.",
-        "change_makeup": [],
+        "change_makeup": [
+            {
+                "type": "HALF",
+                "team": "demon"
+            },
+            {
+                "type": "ZERO",
+                "team": "minion"
+            },
+            {
+                "type": "ARBITRARY",
+                "team": "outsider"
+            }
+        ],
         "image": "assets/icons/official/legion.png",
         "flavor": "We are the chill wind on a winter\u2019s day. We are the shadow in the moonless night. We are the poison in your tea and the whisper in your ear. We are everywhere.",
         "firstNight": 0,
@@ -2513,16 +2461,13 @@
         "otherNightReminder": "Wake all Minions together, allow them to vote by pointing at who they want to babysit Lil' Monsta. Choose a player, that player dies.",
         "change_makeup": [
             {
-                "HARD": [
-                    "min",
-                    1
-                ]
+                "type": "FORCED_CHANGE",
+                "team": "minion",
+                "amount": 1
             },
             {
-                "HARD": [
-                    "min",
-                    -1
-                ]
+                "type": "ZERO",
+                "team": "demon"
             }
         ],
         "image": "assets/icons/official/lilmonsta.png",
@@ -2622,34 +2567,13 @@
         "otherNightReminder": "The Lord of Typhon points to a player. That player dies.",
         "change_makeup": [
             {
-                "SOFTPOS": [
-                    "out",
-                    2
-                ]
+                "type": "ARBITRARY",
+                "team": "outsider"
             },
             {
-                "SOFTNEG": [
-                    "out",
-                    2
-                ]
-            },
-            {
-                "SOFTPOS": [
-                    "townsfolk",
-                    2
-                ]
-            },
-            {
-                "SOFTNEG": [
-                    "townsfolk",
-                    2
-                ]
-            },
-            {
-                "HARDPOS": [
-                    "min",
-                    1
-                ]
+                "type": "FORCED_CHANGE",
+                "team": "minion",
+                "amount": 1
             }
         ],
         "image": "assets/icons/official/lordoftyphon.png",
@@ -3106,9 +3030,7 @@
         "reminders": [],
         "firstNightReminder": "",
         "otherNightReminder": "",
-        "change_makeup": [
-            "Good Players Sober"
-        ],
+        "change_makeup": [],
         "image": "assets/icons/official/nun.png",
         "firstNight": 0,
         "otherNight": 0
@@ -4065,28 +3987,14 @@
         "otherNightReminder": "",
         "change_makeup": [
             {
-                "SOFTPOS": [
-                    "out",
-                    1
-                ]
+                "type": "ALLOWED_INCREASE",
+                "team": "outsider",
+                "amount": 1
             },
             {
-                "SOFTNEG": [
-                    "out",
-                    1
-                ]
-            },
-            {
-                "SOFTPOS": [
-                    "townsfolk",
-                    1
-                ]
-            },
-            {
-                "SOFTNEG": [
-                    "townsfolk",
-                    1
-                ]
+                "type": "ALLOWED_DECREASE",
+                "team": "outsider",
+                "amount": 1
             }
         ],
         "image": "assets/icons/official/sentinel.png",
@@ -4364,16 +4272,8 @@
         "change_makeup": [
             [
                 {
-                    "LOCK": [
-                        "dem",
-                        0
-                    ]
-                },
-                {
-                    "HARD": [
-                        "townsfolk",
-                        1
-                    ]
+                    "type": "ZERO",
+                    "team": "demon"
                 }
             ]
         ],
@@ -4627,7 +4527,12 @@
         "reminders": [],
         "firstNightReminder": "",
         "otherNightReminder": "",
-        "change_makeup": [],
+        "change_makeup": [
+            {
+                "type": "ARBITRARY",
+                "team": "outsider"
+            }
+        ],
         "firstNight": 0,
         "otherNight": 0,
         "image": "assets/icons/official/vatdweller.png"
@@ -4644,7 +4549,13 @@
         ],
         "firstNightReminder": "",
         "otherNightReminder": "The Vigormortis points to a player. That player dies. If a Minion, they keep their ability and one of their Townsfolk neighbours is poisoned.",
-        "change_makeup": [],
+        "change_makeup": [
+            {
+                "type": "FORCED_CHANGE",
+                "team": "outsider",
+                "amount": -1
+            }
+        ],
         "image": "assets/icons/official/vigormortis.png",
         "flavor": "All doors are one door. All keys are one key. All cups are one cup, but whosoever drinketh of the water that I give shall never thirst, but the water shall be in him a well springing up into everlasting life.",
         "firstNight": 0,
@@ -4942,7 +4853,13 @@
         "image": "assets/icons/official/xaan.png",
         "flavor": "Down they fall. One by one. By two, by three, by five.",
         "firstNight": 27,
-        "otherNight": 13
+        "otherNight": 13,
+        "change_makeup": [
+            {
+                "type": "X",
+                "team": "outsider"
+            }
+        ]
     },
     "yaggababble": {
         "id": "yaggababble",

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2304,6 +2304,7 @@
                 "team": "outsider"
             }
         ],
+        "maxCount": 12,
         "image": "assets/icons/official/legion.png",
         "flavor": "We are the chill wind on a winter\u2019s day. We are the shadow in the moonless night. We are the poison in your tea and the whisper in your ear. We are everywhere.",
         "firstNight": 0,
@@ -3262,6 +3263,7 @@
         "firstNightReminder": "Show the finger signal (0, 1, 2) for the number of pirates in play.",
         "otherNightReminder": "",
         "change_makeup": [],
+        "maxCount": 3,
         "image": "assets/icons/official/pirate.png",
         "firstNight": 0,
         "otherNight": 0
@@ -4572,6 +4574,7 @@
         "firstNightReminder": "Wake any Village Idiot. They point to a player. Give a thumbs up or a thumbs down. Put that Village Idiot to sleep. Repeat until all Village Idiots have acted.",
         "otherNightReminder": "Wake any Village Idiot. They point to a player. Give a thumbs up or a thumbs down. Put that Village Idiot to sleep. Repeat until all Village Idiots have acted.",
         "change_makeup": [],
+        "maxCount": 3,
         "image": "assets/icons/official/villageidiot.png",
         "flavor": "Roses are blue, and violets are red, Please reverse what I just said.",
         "firstNight": 63,

--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
                                 <div class="player_count_increment" style="background-color: rgb(0, 129, 0);" onclick="javascript:increment_player_count(1)">+</div>
                             </div>
                         </div>
+                        <div id="menu_issues">Script Errors appear here</div>
                     </div>
                 </div>
                 <div style="width: 100%; text-align: center; margin-top: 30px; height: 80px; display: flex; ">

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
                         <div style="margin-top: 10px;">
                             <div id="player_count_wrapper">
                                 <div class="player_count_increment" style="background-color: rgb(173, 0, 0);" onclick="javascript:increment_player_count(-1)">-</div>
-                                <input type="number" inputmode="numeric" min="5" max="15" value="5" id="player_count" onchange="javascript:player_count_change()"></input>
+                                <input type="number" inputmode="numeric" min="5" max="15" value="5" id="player_count" onchange="javascript:validateSetup()"></input>
                                 <div class="player_count_increment" style="background-color: rgb(0, 129, 0);" onclick="javascript:increment_player_count(1)">+</div>
                             </div>
                         </div>

--- a/main.css
+++ b/main.css
@@ -552,6 +552,15 @@ svg {pointer-events: none; user-select: none;}
 .menu_title        {position: fixed; width: 280px; height: 70px; opacity: 1; background-image: url('assets/botc_logo.png'); background-position: center; background-repeat: no-repeat; background-size: contain; margin: 10px;}
 .menu_body         {position: fixed; width: 280px; height: calc(100% - 110px); padding: 10px; top: 90px; overflow-y: scroll; display: block; font-size: 25px; scrollbar-width: none;}
 .menu_body::-webkit-scrollbar {display: none;}
+#menu_issues {
+    font-size: 15px;
+}
+#menu_issues ul {
+    padding-inline-start: 0.001;
+    tab-size: 1;
+    padding-left: 20px;
+    text-align: left;
+}
 .menu_list         {position: absolute; font-size: 20px; color: white; cursor: pointer;}
 .menu_list_div     {position: relative; cursor: pointer; font-size: 20px; width: 100%; padding-top: 10px;}
 .menu_token_count  {position: absolute; right: 10px; height: 20px; color: white;}

--- a/main.js
+++ b/main.js
@@ -39,7 +39,7 @@ async function loaded() {
   setTimeout(function ()
   {
     loading = false;
-    player_count_change();
+    validateSetup();
   }, 2000)
   document.getElementById("body_actual").setAttribute("orientation", getOrientation())
   window.onresize = resized;

--- a/scripts/infoBox.js
+++ b/scripts/infoBox.js
@@ -94,7 +94,7 @@ function cycle_token_visibility_toggle(id, uid) {
             break;
     }
     update_role_counts();
-    player_count_change();
+    validateSetup();
     populate_night_order();
     if (!loading) { save_game_state(); }
 }

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -69,8 +69,6 @@ function validateSetup() {
     const PLUS_MINUS = String.fromCharCode(177);
     const AT_LEAST = String.fromCodePoint(0x2265);
 
-    console.log(roleData);
-
     for (const type in roleData) {
         const data = roleData[type];
         let output = "";
@@ -132,6 +130,13 @@ function calculateRoleAmounts(playerCount) {
     const roleData = {
         "townsfolk": {
             "count": 0,
+            "roles": [],
+            "required": [
+                // { EX:
+                //     "role": "king",
+                //     "requiredFor": "choirboy"
+                // }
+            ],
             "min": roleCount[0],
             "max": roleCount[0],
             "offset": 0, // plus-minus
@@ -140,6 +145,8 @@ function calculateRoleAmounts(playerCount) {
         },
         "outsider": {
             "count": 0,
+            "roles": [],
+            "required": [],
             "min": roleCount[1],
             "max": roleCount[1],
             "offset": 0,
@@ -148,6 +155,8 @@ function calculateRoleAmounts(playerCount) {
         },
         "minion": {
             "count": 0,
+            "roles": [],
+            "required": [],
             "min": roleCount[2],
             "max": roleCount[2],
             "offset": 0,
@@ -156,6 +165,8 @@ function calculateRoleAmounts(playerCount) {
         },
         "demon": {
             "count": 0,
+            "roles": [],
+            "required": [],
             "min": roleCount[3],
             "max": roleCount[3],
             "offset": 0,
@@ -173,6 +184,7 @@ function calculateRoleAmounts(playerCount) {
 
         if (role.team in roleData) {
             roleData[role.team]["count"] += 1;
+            roleData[role.team]["roles"].push(role.id);
         }
 
         if (!("change_makeup" in role)) continue;
@@ -189,6 +201,7 @@ function calculateRoleAmounts(playerCount) {
             try {
                 const changeKey = change["type"]
                 const affectedData = roleData[change["team"]];
+
                 switch (changeKey) {
                     case "FORCED_CHANGE":
                         // Mandatory change to count.
@@ -207,7 +220,7 @@ function calculateRoleAmounts(playerCount) {
                         affectedData["min"] -= change["amount"];
                         break;
                     case "OFFSET":
-                        // Valid and required change in either direction to count.
+                        // Valid and required change in either direction to exact count.
                         if (affectedData["flag"] != null) break;
                         affectedData["offset"] += change["amount"];
                         break;
@@ -240,6 +253,22 @@ function calculateRoleAmounts(playerCount) {
                         affectedData["min"] = 0;
                         affectedData["max"] = 0;
                         break;
+                    case "REQUIRED":
+                        // A specific role must be in play.
+                        const otherRole = roles[change["role"]]
+                        const otherTypeData = roleData[otherRole.team];
+                        
+                        otherTypeData["required"].push({
+                            "role": change["role"],
+                            "requiredFor": role.id
+                        });
+                        
+                        // If the role is not a townsfolk, it may displace a townsfolk. (Damsel)
+                        if (otherRole.team == "townsfolk") break;
+                        if (otherTypeData["flag"] != null) break;
+                        otherTypeData["max"] += 1;
+
+                        break;
                     default:
                         console.error("Unknown/Invalid Setup modifier: " + changeKey);
                         break;
@@ -259,7 +288,8 @@ function calculateRoleAmounts(playerCount) {
         data["offset"] = Math.max(data["offset"], 0);
     }
 
-    // Townsfolk are whatever is left. We'll compute it now.
+    // Townsfolk are whatever is left. 
+    // Since all setup shenanigans are addressed, we compute the leftovers.
     const townsfolkData = roleData["townsfolk"];
     townsfolkData["max"] = playerCount;
     townsfolkData["min"] = playerCount;
@@ -298,6 +328,7 @@ function setupIssues(roleData, targetPlayerCount) {
 
         totalPlayers += data["count"];
 
+        // Ensure the count is correct.
         if (data["min"] == data["max"]) {
             if (data["count"] != data["min"]) {
                 issue = Issue.EXACT;
@@ -308,6 +339,8 @@ function setupIssues(roleData, targetPlayerCount) {
             }
         }
 
+        // Ensure the count is correct, accounting for offset. 
+        // This could make or break certain setups. 
         if (data["offset"] > 0) {
             if (data["min"] == data["max"]) {
                 if (Math.abs(data["count"] - data["min"]) != data["offset"]) {
@@ -316,12 +349,14 @@ function setupIssues(roleData, targetPlayerCount) {
             } else {
                 if (Math.abs(data["min"] - data["count"]) <= data["offset"]) {
                     issue = Issue.NONE;
-                } else if (Math.abs(data["max"] - data["count"]) <= data["offset"]) {
+                }
+                if (Math.abs(data["max"] - data["count"]) <= data["offset"]) {
                     issue = Issue.NONE;
                 }
             }
         }
 
+        // If Legion or similar is in play, ensure half of the town is that role.
         if (data["flag"] == "HALF") {
             if (data["count"] < data["min"]) {
                 issue = Issue.HALF;
@@ -330,6 +365,7 @@ function setupIssues(roleData, targetPlayerCount) {
             }
         }
 
+        // +/-?? and X. 
         if (data["flag"] == "ARBITRARY") {
             issue = Issue.NONE;
         }
@@ -338,9 +374,8 @@ function setupIssues(roleData, targetPlayerCount) {
             issue = Issue.NONE;
         }
 
+        // Actually adding the issues to the report. 
         const direction = (data["count"] < data["min"] - data["offset"] ? "Not enough" : "Too many"); 
-
-        // console.log(type, data, issue);
 
         switch (issue) {
             case Issue.EXACT:
@@ -361,8 +396,43 @@ function setupIssues(roleData, targetPlayerCount) {
                 data["valid"] = true;
                 break;
         }
+
+        for (const requirement of data["required"]) {
+            if (!data["roles"].includes(requirement["role"])) {
+                const requiredName = roles[requirement["role"]].name;
+                const requiringName = roles[requirement["requiredFor"]].name;
+                issues.push(`The ${requiringName} requires a ${requiredName} be in play. Add the ${requiredName} or remove the ${requiringName}.`);
+            }
+        }
+
+        // Checking for duplicate / too many roles.
+        const roleCounts = {};
+        for (const role of data["roles"]) {
+            if (!(role in roleCounts)) {
+                roleCounts[role] = 0;
+            }
+            roleCounts[role]++;
+        }
+
+        for (const role in roleCounts) {
+            const name = roles[role].name;
+            const times = roleCounts[role];
+            const maxCount = roles[role].maxCount
+            if (maxCount === undefined && times > 1) {
+                issues.push(`The ${name} role appears multiple times. Remove duplicate roles.`);
+            } else if (times > maxCount) {
+                issues.push(`The ${name} role appears more than ${maxCount} times. Remove extra roles.`);
+            }
+        }
     }
 
+    // Hardcoded Atheist exception -- ignore everything that may be wrong. The ST probably knows what they're doing.
+    if (roleData["townsfolk"]["roles"].includes("atheist")) {
+        issues.length = 0; // Apparently this deletes the array. Dammit JS
+        issues.push("Atheist game detected. Are you sure whatever you are doing is worth it?");
+    }
+
+    // Player count validation
     const tokens = Math.abs(targetPlayerCount - totalPlayers) > 1 ? "tokens" : "token";
     if (targetPlayerCount < totalPlayers) {
         issues.push(`Too many tokens for ${targetPlayerCount} players.<br>Remove or hide ${totalPlayers - targetPlayerCount} ${tokens}.`);
@@ -371,9 +441,6 @@ function setupIssues(roleData, targetPlayerCount) {
         issues.push(`Not enough tokens for ${targetPlayerCount} players. Add ${targetPlayerCount - totalPlayers} more ${tokens}.`)
     }
 
-    for (const issue of issues) {
-        console.log(issue);
-    }
     return issues;
 }
 

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -60,42 +60,110 @@ const ROLE_COUNTS = [
 function validateSetup() {
     if (loading) return;
 
-    // Assess default role distribution from player count.
     let playerCount = parseInt(document.getElementById("player_count").value);
     playerCount = Math.min(Math.max(playerCount, 5), 15);
 
-    const roleCount = ROLE_COUNTS[playerCount - 5];
+    const roleData = calculateRoleAmounts(playerCount);
+    const issues = setupIssues(roleData, playerCount);
+
+    const PLUS_MINUS = String.fromCharCode(177);
+    const AT_LEAST = String.fromCodePoint(0x2265);
+
+    console.log(roleData);
+
+    for (const type in roleData) {
+        const data = roleData[type];
+        let output = "";
+
+        if (data["min"] == data["max"]) {
+            output = `${data["count"]} / ${data["min"]}`;
+        } else {
+            output = `${data["count"]} of [${data["min"]} - ${data["max"]}]`;
+        }
+
+        if (data["offset"] > 0) {
+            output += ` ${PLUS_MINUS} ${data["offset"]}`;
+        }
+
+        if (data["flag"] == "HALF") {
+            output = `${data["count"]} ${AT_LEAST} ${data["min"]}`;
+            valid = (data["count"] >= data["min"]);
+        }
+
+        if (data["flag"] == "ARBITRARY") {
+            output = `${data["count"]} / ???`;
+        }
+
+        if (data["flag"] == "X") {
+            output = `X = ${data["count"]}`;
+        }
+
+        const ratio_text = document.getElementById(`ratio_${type}`)
+
+        ratio_text.innerText = output;
+        if (data["valid"]) {
+            ratio_text.style.color = "";
+        } else {
+            ratio_text.style.color = ASSIGNABLE_TEAMS["demon"]["color"];
+        }
+    }
+
+    const menu_issues = document.getElementById("menu_issues")
+    if (issues.length == 0) {
+        menu_issues.style.color = "rgb(179, 179, 0)"
+        menu_issues.innerText = "Everything looks good!"
+    } else {
+        menu_issues.style.color = "rgb(179, 179, 0)"
+        let text = "Detected the following issues:<ul>"
+        for (const issue of issues) {
+            text += `<li>${issue}</li>`;
+        }
+        text += "</ul>";
+        menu_issues.innerHTML = text;
+    }
+    computeDropdownHeight();
     
+}
+
+function calculateRoleAmounts(playerCount) {
+
+    const roleCount = ROLE_COUNTS[playerCount - 5];
+
     const roleData = {
         "townsfolk": {
             "count": 0,
             "min": roleCount[0],
             "max": roleCount[0],
             "offset": 0, // plus-minus
-            "flag": null
+            "flag": null,
+            "valid": false,
         },
         "outsider": {
             "count": 0,
             "min": roleCount[1],
             "max": roleCount[1],
             "offset": 0,
-            "flag": null
+            "flag": null,
+            "valid": false,
         },
         "minion": {
             "count": 0,
             "min": roleCount[2],
             "max": roleCount[2],
             "offset": 0,
-            "flag": null
+            "flag": null,
+            "valid": false,
         },
         "demon": {
             "count": 0,
             "min": roleCount[3],
             "max": roleCount[3],
             "offset": 0,
-            "flag": null
+            "flag": null,
+            "valid": false,
         },
     };
+
 
     const tokens = document.getElementsByClassName("role_token");
     for (const token of tokens) {
@@ -119,7 +187,6 @@ function validateSetup() {
         
         for (const change of role["change_makeup"]) {
             try {
-                console.log(change)
                 const changeKey = change["type"]
                 const affectedData = roleData[change["team"]];
                 switch (changeKey) {
@@ -206,40 +273,108 @@ function validateSetup() {
         townsfolkData["offset"] += otherData["offset"];
     }
 
+    return roleData;
+}
 
-    const PLUS_MINUS = String.fromCharCode(177);
-    const AT_LEAST = String.fromCodePoint(0x2265);
+function pluralize(team) {
+    if (team == "townsfolk") return team;
+    return team + "s";
+}
 
-    console.log(roleData);
+function setupIssues(roleData, targetPlayerCount) {
+    const Issue = {
+        NONE: 0,
+        EXACT: 1,
+        RANGE: 2,
+        OFFSET_REQUIRED: 3,
+        HALF: 4
+    }
 
+    const issues = []
+    let totalPlayers = 0;
     for (const type in roleData) {
+        let issue = Issue.NONE;
         const data = roleData[type];
-        let output = "";
+
+        totalPlayers += data["count"];
 
         if (data["min"] == data["max"]) {
-            output = `${data["count"]} / ${data["min"]}`;
+            if (data["count"] != data["min"]) {
+                issue = Issue.EXACT;
+            }
         } else {
-            output = `${data["count"]} of [${data["min"]} - ${data["max"]}]`;
+            if (data["count"] < data["min"] || data["count"] > data["max"]) {
+                issue = Issue.RANGE;
+            }
         }
 
         if (data["offset"] > 0) {
-            output += ` ${PLUS_MINUS} ${data["offset"]}`;
+            if (data["min"] == data["max"]) {
+                if (Math.abs(data["count"] - data["min"]) != data["offset"]) {
+                    issue = Issue.OFFSET_REQUIRED;
+                }
+            } else {
+                if (Math.abs(data["min"] - data["count"]) <= data["offset"]) {
+                    issue = Issue.NONE;
+                } else if (Math.abs(data["max"] - data["count"]) <= data["offset"]) {
+                    issue = Issue.NONE;
+                }
+            }
         }
 
         if (data["flag"] == "HALF") {
-            output = `${data["count"]} ${AT_LEAST} ${data["min"]}`;
+            if (data["count"] < data["min"]) {
+                issue = Issue.HALF;
+            } else {
+                issue = Issue.NONE;
+            }
         }
 
         if (data["flag"] == "ARBITRARY") {
-            output = `${data["count"]} / ???`;
+            issue = Issue.NONE;
         }
 
         if (data["flag"] == "X") {
-            output = `X = ${data["count"]}`;
+            issue = Issue.NONE;
         }
 
-        document.getElementById(`ratio_${type}`).innerText = output;
+        const direction = (data["count"] < data["min"] - data["offset"] ? "Not enough" : "Too many"); 
+
+        // console.log(type, data, issue);
+
+        switch (issue) {
+            case Issue.EXACT:
+                issues.push(`${direction} ${pluralize(type)}.<br>There should be ${data["min"]}.`);
+                break;
+            case Issue.RANGE:
+                issues.push(`${direction} ${pluralize(type)}.<br>Should be between ${data["min"] - data["offset"]} and ${data["max"] + data["offset"]}.`);
+                break;
+            case Issue.OFFSET_REQUIRED:
+                const type_plural = (data["offset"] > 1 ? pluralize(type) : type);
+                issues.push(`Cannot have exactly ${data["min"]} ${pluralize(type)}.\nAdd or remove ${data["offset"]} ${type_plural}.`);
+                break;
+            case Issue.HALF:
+                issues.push(`${direction} ${pluralize(type)}.\nMore than ${data["min"]} must be ${pluralize(type)}.`)
+
+            default:
+            case Issue.NONE:
+                data["valid"] = true;
+                break;
+        }
     }
+
+    const tokens = Math.abs(targetPlayerCount - totalPlayers) > 1 ? "tokens" : "token";
+    if (targetPlayerCount < totalPlayers) {
+        issues.push(`Too many tokens for ${targetPlayerCount} players.<br>Remove or hide ${totalPlayers - targetPlayerCount} ${tokens}.`);
+    }
+    if (targetPlayerCount > totalPlayers) {
+        issues.push(`Not enough tokens for ${targetPlayerCount} players. Add ${targetPlayerCount - totalPlayers} more ${tokens}.`)
+    }
+
+    for (const issue of issues) {
+        console.log(issue);
+    }
+    return issues;
 }
 
 /**
@@ -278,8 +413,14 @@ function toggle_menu_collapse() {
         dropdown.style.height = "40px";
     } else {
         dropdown.setAttribute("expand", "true");
-        dropdown.style.height = "calc(" + document.getElementById("menu_settings_dropdown_body").scrollHeight + "px + 68px)";
+        computeDropdownHeight();
     }
+}
+
+function computeDropdownHeight() {
+    const dropdown = document.getElementById("menu_settings_dropdown");
+    if (dropdown.getAttribute("expand") != "true") return;
+    dropdown.style.height = `${document.getElementById("menu_settings_dropdown_body").scrollHeight + 68}px`;
 }
 
 /**

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -22,112 +22,223 @@ function close_menu() {
  */
 function increment_player_count(x) {
     document.getElementById("player_count").value = parseInt(document.getElementById("player_count").value) + parseInt(x);
-    player_count_change()
+    validateSetup()
 }
 
+
+const ROLE_COUNTS = [
+    [3, 0, 1, 1], // 5
+    [3, 1, 1, 1], 
+    [5, 0, 1, 1], // 7
+    [5, 1, 1, 1], 
+    [5, 2, 1, 1], 
+    [7, 0, 2, 1], // 10
+    [7, 1, 2, 1], 
+    [7, 2, 2, 1], 
+    [9, 0, 3, 1], // 13
+    [9, 1, 3, 1], 
+    [9, 2, 3, 1], // 15
+
+    // Hypothetical/unimplemented
+    [10, 2, 3, 1], 
+    [11, 2, 3, 1], 
+    [11, 3, 3, 1] // 18
+]
+
 /**
- * Change expected role type distributions based on the number of players.
- * In the menu, this is the Y value in "X / Y".
+ * Perform various setup validations.
+ * This can include any of the following:
+ * 
+ * - Ensuring the outsider count is correct based on other roles
+ * - Correctly reporting ranges or plus-minus changes for outsiders
+ * - Ensuring at least half of all players are Legion (HALF)
+ * - Explicitly showing when role counts are arbitrary
+ * - Explicitly showing when the outsider count must be accounted for (Xaan X)
+ * - Accounting for required roles, such as the Choirboy's King (TODO)
+ * 
  */
-function player_count_change() {
-    var player_count_tmp = document.getElementById("player_count").value;
-    tableIndex = 0;
-    if (player_count_tmp < 5) {
-        document.getElementById("player_count").value = 5;
-        player_count_tmp = 5
-    }
-    let player_count = player_count_tmp;
-    if (player_count_tmp > 15) {
-        player_count_tmp = 15
-    }
-    tableIndex = parseInt(player_count_tmp) - 5;
-    var table = [[3, 0, 1, 1], [3, 1, 1, 1], [5, 0, 1, 1], [5, 1, 1, 1], [5, 2, 1, 1], [7, 0, 2, 1], [7, 1, 2, 1], [7, 2, 2, 1], [9, 0, 3, 1], [9, 1, 3, 1], [9, 2, 3, 1], [10, 2, 3, 1], [11, 2, 3, 1], [11, 3, 3, 1]]
-    var counts = [0, 0, 0, 0, 0];
-    tokens = document.getElementsByClassName("role_token");
-    if (!loading) { //dont try to update player counts before menu is loaded
-        var expected = new Object();
-        // [hard modifier, soft positive modifier, soft negative modifier, locked?]
-        expected.townsfolk = [table[tableIndex][0], 0, 0, false];
-        expected.out = [table[tableIndex][1], 0, 0, false];
-        expected.min = [table[tableIndex][2], 0, 0, false];
-        expected.dem = [table[tableIndex][3], 0, 0, false];
-        expected.trav = [0, 0, 0, false];
-        async function makeupMod(id) {
+function validateSetup() {
+    if (loading) return;
+
+    // Assess default role distribution from player count.
+    let playerCount = parseInt(document.getElementById("player_count").value);
+    playerCount = Math.min(Math.max(playerCount, 5), 15);
+
+    const roleCount = ROLE_COUNTS[playerCount - 5];
+    
+    const roleData = {
+        "townsfolk": {
+            "count": 0,
+            "min": roleCount[0],
+            "max": roleCount[0],
+            "offset": 0, // plus-minus
+            "flag": null
+        },
+        "outsider": {
+            "count": 0,
+            "min": roleCount[1],
+            "max": roleCount[1],
+            "offset": 0,
+            "flag": null
+        },
+        "minion": {
+            "count": 0,
+            "min": roleCount[2],
+            "max": roleCount[2],
+            "offset": 0,
+            "flag": null
+        },
+        "demon": {
+            "count": 0,
+            "min": roleCount[3],
+            "max": roleCount[3],
+            "offset": 0,
+            "flag": null
+        },
+    };
+
+    const tokens = document.getElementsByClassName("role_token");
+    for (const token of tokens) {
+        const role = roles[token.getAttribute("role")];
+
+        if (token.getAttribute("visibility") != "show") continue;
+
+        if (role.team in roleData) {
+            roleData[role.team]["count"] += 1;
+        }
+
+        if (!("change_makeup" in role)) continue;
+
+        const FLAG_PRIORITY = [
+            null,
+            "HALF",
+            "ARBITRARY",
+            "X",
+            "ZERO"
+        ]
+        
+        for (const change of role["change_makeup"]) {
             try {
-                let lambdas = {
-                    "HARD": ((cat, mod) => { expected[cat][0] += mod }),
-                    "SOFTPOS": ((cat, mod) => { expected[cat][1] += mod }),
-                    "SOFTNEG": ((cat, mod) => { expected[cat][2] += mod }),
-                    "REQ": ((cat, val) => { }),
-                    "LOCK": ((cat, val) => {
-                        if (val == -1) {
-                            expected[cat][0] = player_count;
-                        } else {
-                            expected[cat][0] = val;
-                        }
-                        expected[cat][3] = true;
-                        expected[cat][1] = 0;
-                        expected[cat][2] = 0;
-                    })
+                console.log(change)
+                const changeKey = change["type"]
+                const affectedData = roleData[change["team"]];
+                switch (changeKey) {
+                    case "FORCED_CHANGE":
+                        // Mandatory change to count.
+                        if (affectedData["flag"] != null) break;
+                        affectedData["min"] += change["amount"];
+                        affectedData["max"] += change["amount"];
+                        break;
+                    case "ALLOWED_INCREASE":
+                        // Valid but not required increase to count.
+                        if (affectedData["flag"] != null) break;
+                        affectedData["max"] += change["amount"];
+                        break;
+                    case "ALLOWED_DECREASE":
+                        // Valid but not required decrease to count. 
+                        if (affectedData["flag"] != null) break;
+                        affectedData["min"] -= change["amount"];
+                        break;
+                    case "OFFSET":
+                        // Valid and required change in either direction to count.
+                        if (affectedData["flag"] != null) break;
+                        affectedData["offset"] += change["amount"];
+                        break;
+                    case "HALF":
+                        // Most players are this role. 
+                        if (FLAG_PRIORITY.indexOf(affectedData["flag"]) > FLAG_PRIORITY.indexOf("HALF")) break;
+                        affectedData["flag"] = "HALF";
+                        affectedData["min"] = Math.ceil(playerCount / 2.0);
+                        affectedData["max"] = Math.min(playerCount - 2, 12);
+                        break;
+                    case "ARBITRARY":
+                        // The amount of players on this team is arbitrary.
+                        if (FLAG_PRIORITY.indexOf(affectedData["flag"]) > FLAG_PRIORITY.indexOf("ARBITRARY")) break;
+                        affectedData["flag"] = "ARBITRARY";
+                        affectedData["min"] = 0;
+                        affectedData["max"] = 4;
+                        break;
+                    case "X":
+                        // The amount of players on this team is arbitrary, 
+                        // and significant for some ability.
+                        if (FLAG_PRIORITY.indexOf(affectedData["flag"]) > FLAG_PRIORITY.indexOf("X")) break;
+                        affectedData["flag"] = "X";
+                        affectedData["min"] = 0;
+                        affectedData["max"] = 4;
+                        break;
+                    case "ZERO":
+                        // There cannot be any characters of this type.
+                        if (FLAG_PRIORITY.indexOf(affectedData["flag"]) > FLAG_PRIORITY.indexOf("ZERO")) break;
+                        affectedData["flag"] = "ZERO",
+                        affectedData["min"] = 0;
+                        affectedData["max"] = 0;
+                        break;
+                    default:
+                        console.error("Unknown/Invalid Setup modifier: " + changeKey);
+                        break;
                 }
-                let json = roles[id];
-                json["change_makeup"].forEach(element => {
-                    let changeKey = Object.keys(element)[0];
-                    if (!expected[element[changeKey][0]][3]) {
-                        lambdas[changeKey](element[changeKey][0], element[changeKey][1]);
-                    }
-                });
-            } catch { }
-            return Promise.resolve();
+            } catch (e) {
+                console.error(e);
+            }
+            
         }
-        for (i = 0; i < tokens.length; i++) {
-            let visibility = tokens[i].getAttribute("visibility");
-            switch (tokens[i].getAttribute("cat")) {
-                case "townsfolk":
-                    if (visibility == "show") { counts[0]++; }
-                    break;
-                case "outsider":
-                    if (visibility == "show") { counts[1]++; }
-                    break;
-                case "minion":
-                    if (visibility == "show") { counts[2]++; }
-                    break;
-                case "demon":
-                    if (visibility == "show") { counts[3]++; }
-                    break;
-                case "traveller":
-                    if (visibility == "show") { counts[4]++; }
-                    break;
-            }
+    }
+
+    // Ensure nothing is negative.
+    for (const type in roleData) {
+        const data = roleData[type];
+        data["min"] = Math.max(data["min"], 0);
+        data["max"] = Math.max(data["max"], 0);
+        data["offset"] = Math.max(data["offset"], 0);
+    }
+
+    // Townsfolk are whatever is left. We'll compute it now.
+    const townsfolkData = roleData["townsfolk"];
+    townsfolkData["max"] = playerCount;
+    townsfolkData["min"] = playerCount;
+    for (const type in roleData) {
+        if (type == "townsfolk") continue;
+        const otherData = roleData[type];
+        townsfolkData["max"] -= otherData["min"];
+        townsfolkData["max"] = Math.max(townsfolkData["max"], 0);
+        townsfolkData["min"] -= otherData["max"];
+        townsfolkData["min"] = Math.max(townsfolkData["min"], 0);
+        townsfolkData["offset"] += otherData["offset"];
+    }
+
+
+    const PLUS_MINUS = String.fromCharCode(177);
+    const AT_LEAST = String.fromCodePoint(0x2265);
+
+    console.log(roleData);
+
+    for (const type in roleData) {
+        const data = roleData[type];
+        let output = "";
+
+        if (data["min"] == data["max"]) {
+            output = `${data["count"]} / ${data["min"]}`;
+        } else {
+            output = `${data["count"]} of [${data["min"]} - ${data["max"]}]`;
         }
-        for (i = 0; i < tokens.length; i++) {
-            makeupMod(tokens[i].id.match(/.*(?=_token_)/)[0])
+
+        if (data["offset"] > 0) {
+            output += ` ${PLUS_MINUS} ${data["offset"]}`;
         }
-        function genSoftModString(pos, neg) {
-            var string = " "
-            var combined = 0;
-            while (pos > 0 && neg > 0) {
-                combined++;
-                pos--;
-                neg--;
-            }
-            if (combined > 0) {
-                string += String.fromCharCode(177) + combined;
-            }
-            if (pos > 0) {
-                string += " +" + pos;
-            }
-            if (neg > 0) {
-                string += " -" + neg;
-            }
-            return string;
+
+        if (data["flag"] == "HALF") {
+            output = `${data["count"]} ${AT_LEAST} ${data["min"]}`;
         }
-        document.getElementById("ratio_townsfolk").innerHTML = counts[0] + "/" + expected["townsfolk"][0] + genSoftModString(expected["townsfolk"][1], expected["townsfolk"][2]);
-        document.getElementById("ratio_outsider").innerHTML = counts[1] + "/" + expected["out"][0] + genSoftModString(expected["out"][1], expected["out"][2]);
-        document.getElementById("ratio_minion").innerHTML = counts[2] + "/" + expected["min"][0] + genSoftModString(expected["min"][1], expected["min"][2]);
-        document.getElementById("ratio_demon").innerHTML = counts[3] + "/" + expected["dem"][0] + genSoftModString(expected["dem"][1], expected["dem"][2]);
-        if (player_count > 15 && !expected["trav"][3]) { expected["trav"][0] += player_count - 15 }
-        document.getElementById("ratio_traveller").innerHTML = counts[4] + "/" + expected["trav"][0] + genSoftModString(expected["trav"][1], expected["trav"][2]);
+
+        if (data["flag"] == "ARBITRARY") {
+            output = `${data["count"]} / ???`;
+        }
+
+        if (data["flag"] == "X") {
+            output = `X = ${data["count"]}`;
+        }
+
+        document.getElementById(`ratio_${type}`).innerText = output;
     }
 }
 

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -156,7 +156,10 @@ async function populate_script(script) {
 
         var ratio = document.createElement("div");
         ratio.classList = "menu_ratio";
-        ratio.innerHTML = "0/0";
+        ratio.innerText = "0 / 0";
+        if (team.id in ["fabled", "traveller"]) {
+            ratio.innerText = "0";
+        }
         ratio.id = "ratio_" + team.id
         landing.appendChild(ratio);
 
@@ -212,7 +215,7 @@ async function populate_script(script) {
         landing.appendChild(outer_div)
     }
 
-    player_count_change();
+    validateSetup();
     update_role_counts();
 
     resetInfoList();

--- a/scripts/token.js
+++ b/scripts/token.js
@@ -114,7 +114,7 @@ function spawnToken(id, uid, visibility, cat, hide_face, viability, left, top, n
     }
     // Random admin stuff.
     update_role_counts();
-    player_count_change();
+    validateSetup();
     makeDraggable(div);
     populate_night_order();
 
@@ -201,7 +201,7 @@ function remove_token(id, uid) {
     rm.parentNode.removeChild(rm);
     clean_tokens(uid);
     update_role_counts();
-    player_count_change();
+    validateSetup();
     hideInfo();
     populate_night_order();
 }


### PR DESCRIPTION
Added the ability for the grimoire to detect and alert the Storyteller to potential setup issues. 
<img width="1013" height="886" alt="image" src="https://github.com/user-attachments/assets/40fed4b6-7c77-4b5c-9cfb-9606c668b7af" />
This allows the grimoire to detect all potential setup issues that can occur with the tokens that are in play, including
- Hard outsider modification, such as the Baron. 
- Suggested outsider modification, such as the Balloonist. 
- Roles that change the outsider modification in either direction, such as the Godfather. 
- Roles that require other roles, like the Huntsman or choirboy. 
- Roles that make outsiders arbitrary, such as the Kazali.
- Roles that depend on the outsider count, such as the Xaan.
- Roles that require half of all players to be that role, such as Legion. 
- The Atheist.
All issues are compiled and reported under the player count setting, in the collapsible.
This is purely advisory, and can just be ignored by the Storyteller. It also doesn't account for more complex interactions, such as an alchemist-Baron, Lil' Monsta, or self-removing Hermit. 
<img width="1861" height="1098" alt="image" src="https://github.com/user-attachments/assets/0f78508c-68ee-418b-aceb-c0e1320f31f1" />
