### PR TITLE
Added the unreleased experimentals we use often to the night order.

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -313,7 +313,7 @@
         "otherNightReminder": "",
         "change_makeup": [],
         "image": "assets/icons/official/ballerina.png",
-        "firstNight": 0,
+        "firstNight": 62.5,
         "otherNight": 0
     },
     "balloonist": {
@@ -464,7 +464,7 @@
         "change_makeup": [],
         "image": "assets/icons/official/barrowfog.png",
         "firstNight": 0,
-        "otherNight": 0
+        "otherNight": 52.5
     },
     "beekeeper": {
         "id": "beekeeper",
@@ -1117,11 +1117,11 @@
         "reminders": [
             "Seen"
         ],
-        "firstNightReminder": "Show the Governess which players are minions.",
+        "firstNightReminder": "Show the Diplomat which players are minions.",
         "otherNightReminder": "",
         "change_makeup": [],
         "image": "assets/icons/official/diplomat.png",
-        "firstNight": 0,
+        "firstNight": 62.8,
         "otherNight": 0
     },
     "djinn": {
@@ -2295,8 +2295,8 @@
         "otherNightReminder": "The Klaun points to 3 players, mark those players as 'mad' then wake them and inform them they are mad of some character.",
         "change_makeup": [],
         "image": "assets/icons/official/klaun.png",
-        "firstNight": 0,
-        "otherNight": 0
+        "firstNight": 40.5,
+        "otherNight": 28.5
     },
     "klutz": {
         "id": "klutz",
@@ -3596,7 +3596,7 @@
         "otherNightReminder": "",
         "change_makeup": [],
         "image": "assets/icons/official/prisoner.png",
-        "firstNight": 0,
+        "firstNight": 43.3,
         "otherNight": 0
     },
     "professor": {
@@ -3724,7 +3724,7 @@
         "change_makeup": [],
         "image": "assets/icons/official/queenoflies.png",
         "firstNight": 0,
-        "otherNight": 0
+        "otherNight": 52.7
     },
     "ravenkeeper": {
         "id": "ravenkeeper",
@@ -3796,8 +3796,8 @@
         "otherNightReminder": "",
         "change_makeup": [],
         "image": "assets/icons/official/ringmaster.png",
-        "firstNight": 0,
-        "otherNight": 0
+        "firstNight": 0.1,
+        "otherNight": 0.1
     },
     "riot": {
         "id": "riot",
@@ -4528,7 +4528,7 @@
         "otherNightReminder": "The Tipi-Tipi chooses a player, If this is the final night they are mad, otherwise they die.",
         "change_makeup": [],
         "firstNight": 0,
-        "otherNight": 0,
+        "otherNight": 52.9,
         "image": "assets/icons/official/tipitipi.png"
     },
     "towncrier": {

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -3280,8 +3280,8 @@
         "otherNightReminder": "If this is the night the patient wakes up, the Patient points to a player, they gain their ability for each night they were not waken up.",
         "change_makeup": [],
         "image": "assets/icons/official/patient.png",
-        "firstNight": 0,
-        "otherNight": 0
+        "firstNight": 10.2,
+        "otherNight": 8.5
     },
     "philosopher": {
         "id": "philosopher",


### PR DESCRIPTION
Also fixed a typo that called the Diplomat the Governess. 

I added Ballerina (after shugenja), diplomat (after ballerina), klaun (after harpy), ringmaster (at the beginning of the night), barrow fog (at the end of the demons), tipi-tipi (after barrow fog), queen of lies (after tipi-tipi), and prisoner (after pixie). 